### PR TITLE
Remove SideOnly annotation that causes server crash

### DIFF
--- a/MODSRC/vazkii/gencreator/DataStorage.java
+++ b/MODSRC/vazkii/gencreator/DataStorage.java
@@ -30,7 +30,6 @@ public class DataStorage {
 	@SideOnly(Side.CLIENT)
 	public static BoundingBox selection;
 
-	@SideOnly(Side.CLIENT)
 	public static List<String> usedNames = new ArrayList();
 
 	public static List<StructureData> structures = new ArrayList();


### PR DESCRIPTION
Removes SideOnly annotation, since Forge removes the field but doesn't know enough to remove the initialization. Fixes #2.
